### PR TITLE
Boosting bitswap

### DIFF
--- a/src/cpp/src/encoders/sse_utils.hpp
+++ b/src/cpp/src/encoders/sse_utils.hpp
@@ -1156,7 +1156,7 @@ namespace sqeazy {
 
       const        std::size_t len                  = std::distance(_begin,_end);
       const        std::size_t n_iterations         = len/n_elements_per_simd;
-      const        std::size_t n_collected_bits_per_simd        = n_elements_per_simd;
+      static const std::size_t n_collected_bits_per_simd        = n_elements_per_simd;
 
       /* will be .5 for uint8, 2 for uint16 and 4 for uint32 */
       const        std::size_t n_inner_loops        = n_bits_in_value_t / n_collected_bits_per_simd;
@@ -1184,7 +1184,7 @@ namespace sqeazy {
 
           in_value_t temp = collect(input_block);
 
-          result |= (temp << (l*n_collected_bits_per_simd));
+          result |= (temp << (n_bits_in_value_t - ((l+1)*n_collected_bits_per_simd)));
 
         }// l filled_segments
 

--- a/src/cpp/src/encoders/sse_utils.hpp
+++ b/src/cpp/src/encoders/sse_utils.hpp
@@ -1152,7 +1152,7 @@ namespace sqeazy {
       static const std::size_t n_bits_in_value_t	= sizeof(in_value_t)*CHAR_BIT;
       static const std::size_t n_elements_per_simd	= n_bits_per_simd/(n_bits_in_value_t);
 
-      // std::array<out_value_t, n_elements_per_simd> buffer;buffer.fill(0);
+      std::array<out_value_t, n_elements_per_simd> buffer;buffer.fill(0);
 
       const        std::size_t len                  = std::distance(_begin,_end);
       const        std::size_t n_iterations         = len/n_elements_per_simd;
@@ -1167,7 +1167,6 @@ namespace sqeazy {
       auto output = _dst;
       auto input = _begin;
       std::uint32_t pos = 0;
-      __m128i output_block = _mm_set1_epi8(0);
 
       for(std::size_t i = 0;i<n_iterations;i+=n_inner_loops)//loop through memory
       {
@@ -1188,15 +1187,12 @@ namespace sqeazy {
 
         }// l filled_segments
 
-        // buffer[pos] = result;
-        output_block = sse_scalar<in_value_t>::insert(output_block,result,pos);
+        buffer[pos] = result;
         pos++;
 
         if(pos > (n_elements_per_simd-1)){//flush to output memory
-          //std::copy(buffer.begin(),buffer.end(),output);
-          //buffer.fill(0);
-          _mm_store_si128(reinterpret_cast<__m128i*>(&*output),output_block);
-          output_block = _mm_set1_epi8(0);
+          std::copy(buffer.begin(),buffer.end(),output);
+          buffer.fill(0);
           output += n_elements_per_simd;
           pos = 0;
         }
@@ -1246,7 +1242,7 @@ namespace sqeazy {
       static const std::size_t n_elements_per_simd	= n_bits_per_simd/(n_bits_in_value_t);
       static const std::size_t n_uint16_per_simd	= sizeof(__m128i)/sizeof(std::uint16_t);
 
-      //std::array<std::uint16_t, n_uint16_per_simd> buffer;buffer.fill(0);
+      std::array<std::uint16_t, n_uint16_per_simd> buffer;buffer.fill(0);
 
       const        std::size_t len                  = std::distance(_begin,_end);
 
@@ -1255,7 +1251,6 @@ namespace sqeazy {
 
       auto output = _dst;
       std::uint32_t pos = 0;
-     __m128i output_block = _mm_set1_epi8(0);
 
       for(std::size_t i = 0;i<len;i+=n_elements_per_simd)//loop through memory
       {
@@ -1266,15 +1261,12 @@ namespace sqeazy {
         input_block = shift_left(input_block);
         std::uint16_t temp = collect(input_block);
 
-        //buffer[pos] = temp;
-        output_block = sse_scalar<std::uint16_t>::insert(output_block,temp,pos);
+        buffer[pos] = temp;
         pos++;
 
         if(pos > 7){//flush to output memory
-          _mm_store_si128(reinterpret_cast<__m128i*>(&*output),output_block);
-          output_block = _mm_set1_epi8(0);
-          //std::copy(buffer.begin(),buffer.end(),reinterpret_cast<std::uint16_t*>(&*output));
-          //buffer.fill(0);
+          std::copy(buffer.begin(),buffer.end(),reinterpret_cast<std::uint16_t*>(&*output));
+          buffer.fill(0);
           output += n_elements_per_simd;
           pos = 0;
         }

--- a/src/cpp/tests/test_bitplane_reorder_on_ramp_impl.cpp
+++ b/src/cpp/tests/test_bitplane_reorder_on_ramp_impl.cpp
@@ -355,19 +355,20 @@ BOOST_AUTO_TEST_CASE( shift_left_by_9_all ){
 
 BOOST_AUTO_TEST_CASE( versus_default_first_128 ){
 
-  int ret1 = sqeazy::detail::sse_bitplane_reorder_encode<1>(&input[0], &output[0], 128);
-  int ret2 = sqeazy::detail::scalar_bitplane_reorder_encode<1>(&input[0], &reference[0], 128);
+  const unsigned n_el = 128;
+  int ret1 = sqeazy::detail::sse_bitplane_reorder_encode<1>(&input[0], &output[0], n_el);
+  int ret2 = sqeazy::detail::scalar_bitplane_reorder_encode<1>(&input[0], &reference[0], n_el);
 
 
   BOOST_REQUIRE(ret1 == ret2);
 
-  for(unsigned i = 0;i<128;++i){
+  for(unsigned i = 0;i<n_el;++i){
 
     try{
       BOOST_REQUIRE(output[i] == reference[i]);
     }
     catch(...){
-      std::cerr << "[versus_default_first_128] " << i << " / "<< 128<<" item does not match "
+      std::cerr << "[versus_default_first_128] " << i << " / "<< n_el<<" item does not match "
         << "scalar :" <<  output[i] << ", "
         << "sse    :" <<  reference[i]
         << "\n";


### PR DESCRIPTION
bitswap performance before:
```
Run on (4 X 3600 MHz CPU s)
2017-12-01 13:24:20
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
------------------------------------------------------------------------------------------------------------
Benchmark                                                                     Time           CPU Iterations
------------------------------------------------------------------------------------------------------------
static_default_fixture/one_vs_two_threads/real_time/threads:2          14682404 ns   27663150 ns         50    544.87MB/s
static_default_fixture/one_vs_two_threads/real_time/threads:1          35588853 ns   35398892 ns         20   224.789MB/s
static_default_fixture/scalar_one_vs_two_threads/real_time/threads:2  238099402 ns  431865257 ns          4   33.5994MB/s
static_default_fixture/scalar_one_vs_two_threads/real_time/threads:1  454890426 ns  452986043 ns          2   17.5867MB/s
static_default_fixture/sse_one_vs_two_threads/real_time/threads:2      14403518 ns   27998310 ns         48    555.42MB/s
static_default_fixture/sse_one_vs_two_threads/real_time/threads:1      35567549 ns   35331986 ns         19   224.924MB/s
dynamic_default_fixture/single_thread/65536                              527918 ns     527024 ns       1326   237.181MB/s
dynamic_default_fixture/single_thread/262144                            2102965 ns    2099451 ns        329   238.158MB/s
dynamic_default_fixture/single_thread/2097152                          17742729 ns   17644874 ns         40   226.695MB/s
dynamic_default_fixture/single_thread/16777216                        141826680 ns  140994170 ns          5    226.96MB/s
dynamic_default_fixture/single_thread/33554432                        286663578 ns  285082828 ns          2   224.496MB/s
dynamic_default_fixture/two_threads/65536/real_time                      289868 ns     289316 ns       2462   431.231MB/s
dynamic_default_fixture/two_threads/262144/real_time                    1150745 ns    1146000 ns        631   434.501MB/s
dynamic_default_fixture/two_threads/2097152/real_time                   9898162 ns    9728036 ns         74   404.115MB/s
dynamic_default_fixture/two_threads/16777216/real_time                 76926927 ns   75908432 ns         10   415.979MB/s
dynamic_default_fixture/two_threads/33554432/real_time                147945719 ns  147087969 ns          5   432.591MB/s
dynamic_default_fixture/max_threads/65536/real_time                      246242 ns     238720 ns       2763   507.631MB/s
dynamic_default_fixture/max_threads/262144/real_time                     947072 ns     923972 ns        765   527.943MB/s
dynamic_default_fixture/max_threads/2097152/real_time                   7849813 ns    7547781 ns         94   509.566MB/s
dynamic_default_fixture/max_threads/16777216/real_time                 58815137 ns   56967048 ns         11   544.078MB/s
dynamic_default_fixture/max_threads/33554432/real_time                118987156 ns  111269561 ns          6   537.873MB/s
```
performance after:
```
Run on (4 X 3600 MHz CPU s)
2017-12-01 13:30:04
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
------------------------------------------------------------------------------------------------------------
Benchmark                                                                     Time           CPU Iterations
------------------------------------------------------------------------------------------------------------
static_default_fixture/one_vs_two_threads/real_time/threads:2           8369199 ns   16195068 ns         86   955.886MB/s
static_default_fixture/one_vs_two_threads/real_time/threads:1          17032470 ns   16913603 ns         40   469.691MB/s
static_default_fixture/scalar_one_vs_two_threads/real_time/threads:2  232559137 ns  454802324 ns          4   34.3999MB/s
static_default_fixture/scalar_one_vs_two_threads/real_time/threads:1  452403169 ns  451903429 ns          2   17.6833MB/s
static_default_fixture/sse_one_vs_two_threads/real_time/threads:2       8493742 ns   16152430 ns         84    941.87MB/s
static_default_fixture/sse_one_vs_two_threads/real_time/threads:1      17158517 ns   16996786 ns         41   466.241MB/s
dynamic_default_fixture/single_thread/65536                              243826 ns     243065 ns       2902   514.266MB/s
dynamic_default_fixture/single_thread/262144                             951519 ns     949262 ns        734   526.725MB/s
dynamic_default_fixture/single_thread/2097152                           8304067 ns    8218670 ns         85   486.697MB/s
dynamic_default_fixture/single_thread/16777216                         67731225 ns   66996771 ns         10   477.635MB/s
dynamic_default_fixture/single_thread/33554432                        135295278 ns  133963546 ns          5   477.742MB/s
dynamic_default_fixture/two_threads/65536/real_time                      128301 ns     127944 ns       5044   974.271MB/s
dynamic_default_fixture/two_threads/262144/real_time                     518938 ns     517577 ns       1382   963.506MB/s
dynamic_default_fixture/two_threads/2097152/real_time                   4436557 ns    4351549 ns        155     901.6MB/s
dynamic_default_fixture/two_threads/16777216/real_time                 37429130 ns   36364691 ns         19   854.949MB/s
dynamic_default_fixture/two_threads/33554432/real_time                 71785677 ns   70976594 ns         10   891.543MB/s
dynamic_default_fixture/max_threads/65536/real_time                      146282 ns     139689 ns       5475   854.515MB/s
dynamic_default_fixture/max_threads/262144/real_time                     523008 ns     508537 ns       1411   956.009MB/s
dynamic_default_fixture/max_threads/2097152/real_time                   4051999 ns    4012927 ns        158   987.167MB/s
dynamic_default_fixture/max_threads/16777216/real_time                 34699402 ns   32502108 ns         20   922.206MB/s
dynamic_default_fixture/max_threads/33554432/real_time                 67841508 ns   65591122 ns         11   943.375MB/s
```